### PR TITLE
Add RPC to core

### DIFF
--- a/common_protos/universal_messages.proto
+++ b/common_protos/universal_messages.proto
@@ -102,6 +102,7 @@ message Cfg {
 message PluginType {
 	oneof plugin_type {
 		RustFFIConfig rust_plugin = 1;
+		RpcConfig rpc = 2;
 	}
 }
 
@@ -118,6 +119,7 @@ message InitAs {
 		ModuleInit module = 2;
 	}
 }
+
 
 // Initialization marker for a Backend.
 // See InitAs for more info.
@@ -140,6 +142,15 @@ message ModuleInit {
 message RustFFIConfig {
 	required string plugin_path = 1;
 	required InitAs init_as = 2;
+}
+
+message RpcConfig {
+	optional string ip = 1 [default="127.0.0.1"];
+	optional uint32 port = 2 [default=6112];
+	optional string command = 3;
+	repeated string command_args = 4;
+
+	required InitAs init_as = 5;
 }
 
 // Configuration of a Backend. This is handled

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ libloading="0.4.1"
 prost = "0.2"
 libc = "0.2"
 lazy_static = "0.2"
+websocket="0.20"
 
 # local deps
 scaii_defs = {path = "../scaii_defs"}

--- a/core/src/internal/mod.rs
+++ b/core/src/internal/mod.rs
@@ -1,8 +1,16 @@
 pub mod router;
 pub mod agent;
 pub mod rust_ffi;
+pub mod rpc;
 
 use libloading::Library;
+
+use scaii_defs::{Module, Backend};
+
+pub enum LoadedAs {
+    Module(Box<Module>, String),
+    Backend(Box<Backend>),
+}
 
 use std::sync::Mutex;
 use std::collections::HashMap;

--- a/core/src/internal/rpc/mod.rs
+++ b/core/src/internal/rpc/mod.rs
@@ -1,0 +1,195 @@
+use scaii_defs::Module;
+use scaii_defs::protos::{MultiMessage, ScaiiPacket};
+use scaii_defs::protos::{ModuleInit, RpcConfig};
+use std::error::Error;
+use std::net::{IpAddr, SocketAddr};
+
+use websocket::client::sync::Client;
+use websocket::stream::sync::TcpStream;
+
+use scaii_defs::protos::endpoint::Endpoint;
+
+use super::LoadedAs;
+
+#[cfg(test)]
+mod test;
+
+pub fn init_rpc(rpc_config: RpcConfig) -> Result<LoadedAs, Box<Error>> {
+    use scaii_defs::protos::init_as::InitAs;
+    use scaii_defs::protos::endpoint::Endpoint;
+    use scaii_defs::protos;
+
+    let client = connect(&rpc_config)?;
+
+    match rpc_config.init_as.init_as.ok_or::<Box<Error>>(From::from(
+        "Malformed InitAs field in RpcPlugin"
+            .to_string(),
+    ))? {
+        InitAs::Module(ModuleInit { name }) => Ok(LoadedAs::Module(
+            Box::new(RpcModule {
+                rpc: Rpc {
+                    socket_client: client,
+                    inbound_messages: Vec::with_capacity(5),
+                    owner: Endpoint::Module(protos::ModuleEndpoint { name: name.clone() }),
+                },
+            }),
+            name,
+        )),
+        _ => unimplemented!("Still need to implement Backend match arm"),
+    }
+
+}
+
+struct Rpc {
+    socket_client: Client<TcpStream>,
+    inbound_messages: Vec<MultiMessage>,
+    owner: Endpoint,
+}
+
+
+impl Rpc {
+    pub fn send_message(&mut self, msg: &ScaiiPacket) {
+        use scaii_defs::protos;
+        use scaii_defs::protos::scaii_packet;
+
+        let result = encode_and_send_proto(&mut self.socket_client, msg);
+        match result {
+            Ok(()) => {
+                let packet = receive_and_decode_proto(&mut self.socket_client).unwrap_or_else(|e| {
+                    let err_packet = ScaiiPacket {
+                        src: protos::Endpoint{
+                            endpoint: Some(Endpoint::Core(protos::CoreEndpoint{}))
+                        },
+                        dest: protos::Endpoint{ endpoint: Some(self.owner.clone())},
+                        specific_msg: Some(scaii_packet::SpecificMsg::Err(
+                            protos::Error {
+                                fatal: None,
+                                description: format!("Error decoding in core: {}", e),
+                            }
+                        ))
+                    };
+
+                    MultiMessage{ packets: vec![err_packet ]}
+                });
+
+                self.inbound_messages.push(packet);
+            }
+            Err(e) => {
+                // Send error msg to ourselves.
+                let err_packet = ScaiiPacket {
+                    src: protos::Endpoint {
+                        endpoint: Some(Endpoint::Core(protos::CoreEndpoint {})),
+                    },
+                    dest: protos::Endpoint {
+                        endpoint: Some(Endpoint::Core(protos::CoreEndpoint {})),
+                    },
+                    specific_msg: Some(scaii_packet::SpecificMsg::Err(protos::Error {
+                        fatal: None,
+                        description: format!(
+                            "Could not communicate with RPC plugin: {:?}.\n Err: {}",
+                            self.owner,
+                            e
+                        ),
+                    })),
+                };
+
+                self.inbound_messages.push(MultiMessage {
+                    packets: vec![err_packet],
+                });
+            }
+        }
+    }
+    pub fn get_messages(&mut self) -> MultiMessage {
+        use scaii_defs::protos;
+        protos::merge_multi_messages(self.inbound_messages.drain(..).collect())
+            .unwrap_or(MultiMessage { packets: Vec::new() })
+    }
+}
+
+struct RpcModule {
+    rpc: Rpc,
+}
+
+impl Module for RpcModule {
+    fn process_msg(&mut self, msg: &ScaiiPacket) -> Result<(), Box<Error>> {
+        self.rpc.send_message(msg);
+        Ok(()) // TODO -return something meaningful
+    }
+
+    fn get_messages(&mut self) -> MultiMessage {
+        let m_message = self.rpc.get_messages();
+        m_message
+    }
+}
+
+
+fn receive_and_decode_proto(client: &mut Client<TcpStream>) -> Result<MultiMessage, Box<Error>> {
+    use scaii_defs::protos::MultiMessage;
+    use prost::Message;
+    use websocket::OwnedMessage;
+
+    let msg = client.recv_message()?;
+    if let OwnedMessage::Binary(vec) = msg {
+        Ok(MultiMessage::decode(vec)?)
+    } else if let OwnedMessage::Close(dat) = msg {
+        Err(From::from(format!("Client closed connection: {:?}", dat)))
+    } else {
+        Err(From::from("Client sent malformed multimessage".to_string()))
+    }
+}
+
+
+fn encode_and_send_proto(
+    client: &mut Client<TcpStream>,
+    packet: &ScaiiPacket,
+) -> Result<(), Box<Error>> {
+    use prost::Message;
+    use websocket::message;
+    let mut buf: Vec<u8> = Vec::new();
+    packet.encode(&mut buf)?;
+
+    client.send_message(&message::Message::binary(buf))?;
+    Ok(())
+}
+
+
+fn connect(settings: &RpcConfig) -> Result<Client<TcpStream>, Box<Error>> {
+    use websocket::sync::Server;
+    use std::str::FromStr;
+    use std::time::Duration;
+    use std::{u16, u32};
+
+    let port = settings.port.unwrap();
+    if port > u16::MAX as u32 {
+        return Err(From::from(
+            "Port overflows uint16, \
+             protobuf does not have uint16 so it's your responsibility to \
+             not attempt to bind to a port higher than that.",
+        ));
+    }
+
+    let mut server = Server::bind(SocketAddr::new(
+        IpAddr::from_str(&settings.ip.as_ref().unwrap())?,
+        port as u16,
+    ))?;
+    let connection = match server.accept() {
+        Err(err) => return Err(Box::new(err.error)),
+        Ok(connection) => connection,
+    };
+
+    connection.tcp_stream().set_read_timeout(
+        Some(Duration::new(500, 0)),
+    )?;
+
+    connection.tcp_stream().set_write_timeout(
+        Some(Duration::new(500, 0)),
+    )?;
+
+    match connection.accept() {
+        Ok(conn) => Ok(conn),
+        // Ignore the returned server since we're not
+        // going to reattempt connections, just alert
+        // the user of the error
+        Err((_, err)) => Err(Box::new(err)),
+    }
+}

--- a/core/src/internal/rpc/test.rs
+++ b/core/src/internal/rpc/test.rs
@@ -1,0 +1,121 @@
+use scaii_defs::protos::{MultiMessage, ScaiiPacket};
+use std::sync::mpsc;
+use std::thread;
+use websocket::message;
+use websocket::OwnedMessage;
+use scaii_defs::protos;
+
+#[test]
+fn connect_attempt() {
+    use super::*;
+    use scaii_defs::protos::InitAs;
+    use scaii_defs::protos::ModuleInit;
+    use scaii_defs::protos::scaii_packet;
+    let (tx, rx) = mpsc::channel();
+    // start a thread that starts listening on the port
+    let handle = thread::spawn(move || {
+        let config = RpcConfig {
+            ip: Some("127.0.0.1".to_string()),
+            port: Some(6112),
+            init_as: InitAs {
+                init_as: Some(protos::init_as::InitAs::Module(
+                    ModuleInit { name: String::from("RpcPluginModule") },
+                )),
+            },
+            command: None,
+            command_args: Vec::new(),
+        };
+        let result = init_rpc(config).expect("trying to init_rpc");
+        match result {
+            LoadedAs::Module(mut rpc_module, _) => {
+                println!("RPCModule here");
+                // we'll get here after the wakeup connectioncomes in
+                let dummy_scaii_pkt = get_dummy_scaii_pkt();
+                // send the message
+                rpc_module.process_msg(&dummy_scaii_pkt).unwrap();
+                let mut multi_message = rpc_module.get_messages();
+                println!("AAA");
+                let pkt = multi_message.packets.pop().unwrap();
+                println!("BBB");
+                if pkt.specific_msg ==
+                    Some(scaii_packet::SpecificMsg::VizInit(protos::VizInit {}))
+                {
+                    tx.send(String::from("success")).unwrap();
+                } else {
+                    tx.send(String::from("fail")).unwrap();
+                }
+            }
+            LoadedAs::Backend(_) => (),
+        }
+    });
+
+    // connect to the port and send a message
+    use websocket::ClientBuilder;
+
+    let mut client = ClientBuilder::new("ws://127.0.0.1:6112")
+        .unwrap()
+        .connect_insecure()
+        .unwrap();
+    println!("connected via Client::bind");
+    let msg = client.recv_message().expect(
+        "Could not receive ping message from local client",
+    );
+    println!("msg received was {:?} ", msg);
+    let scaii_packet = decode_scaii_packet(msg);
+    let mut pkt_vec: Vec<ScaiiPacket> = Vec::new();
+    pkt_vec.push(scaii_packet);
+    let multi_message = protos::MultiMessage { packets: pkt_vec };
+
+    let buf = encode_multi_message(&multi_message);
+    client.send_message(&message::Message::binary(buf)).unwrap();
+    println!("sent echo message from far client");
+    let payload = rx.recv().unwrap();
+    assert!(payload == String::from("success"));
+    handle.join().unwrap();
+}
+
+fn get_dummy_scaii_pkt() -> ScaiiPacket {
+    use scaii_defs::protos;
+    use scaii_defs::protos::{endpoint, scaii_packet};
+    ScaiiPacket {
+        src: protos::Endpoint {
+            endpoint: Some(endpoint::Endpoint::Backend(protos::BackendEndpoint {})),
+        },
+        dest: protos::Endpoint {
+            endpoint: Some(endpoint::Endpoint::Module(
+                protos::ModuleEndpoint { name: "viz".to_string() },
+            )),
+        },
+        specific_msg: Some(scaii_packet::SpecificMsg::VizInit(protos::VizInit {})),
+    }
+}
+fn encode_multi_message(
+    //packet: &ScaiiPacket,
+    multi_message: &MultiMessage
+) -> Vec<u8> {
+    use prost::Message;
+    let mut buf: Vec<u8> = Vec::new();
+    //packet.encode(&mut buf).expect(
+    multi_message.encode(&mut buf).expect(
+        "Could not encode SCAII packet (server error)",
+    );
+    buf
+}
+
+fn decode_scaii_packet(msg: OwnedMessage) -> ScaiiPacket {
+    use prost::Message;
+
+    if let OwnedMessage::Binary(vec) = msg {
+        match ScaiiPacket::decode(vec) {
+            Err(err) => {
+                panic!("Client send something that couldn't be decoded {}", err);
+            }
+            Ok(msg) => msg,
+        }
+    } else if let OwnedMessage::Close(dat) = msg {
+        panic!("Client closed connection: {:?}", dat);
+    } else {
+        // 1008 = Policy Violation
+        panic!("Client failed to send valid response");
+    }
+}

--- a/core/src/internal/rust_ffi.rs
+++ b/core/src/internal/rust_ffi.rs
@@ -4,10 +4,7 @@ use scaii_defs::protos::{MultiMessage, ScaiiPacket, RustFfiConfig};
 use std::error::Error;
 use std::ops::{Deref, DerefMut, Drop};
 
-pub enum LoadedAs {
-    Module(Box<Module>, String),
-    Backend(Box<Backend>),
-}
+use super::LoadedAs;
 
 pub fn init_ffi(args: RustFfiConfig) -> Result<LoadedAs, Box<Error>> {
     use internal::RcLibrary;


### PR DESCRIPTION
Add RPC plugin handling to core.
Currently this does not handle backends or agents,
only modules (like Viz).