### PR TITLE
Collision Rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "specs"
 version = "0.10.0"
-source = "git+https://github.com/LinearZoetrope/specs#8b881855146e3e9381abdfff450f6185be329ad1"
+source = "git+https://github.com/LinearZoetrope/specs#be9c1cef1d7f5952203ec1e34cd2e6a7351351ec"
 dependencies = [
  "crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/backends/sky-rts/src/engine/components/collision.rs
+++ b/backends/sky-rts/src/engine/components/collision.rs
@@ -1,10 +1,110 @@
+use std::fmt::Debug;
+
 use ncollide::world::CollisionObjectHandle;
+use specs::error::NoError;
 use specs::prelude::*;
+use specs::saveload::SaveLoadComponent;
+use specs::storage::HashMapStorage;
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, Component, PartialEq, Eq)]
 #[storage(VecStorage)]
 pub struct CollisionHandle(pub CollisionObjectHandle);
 
-#[derive(Debug, Clone, Copy, Component, PartialEq, Eq)]
-#[storage(VecStorage)]
-pub struct AttackSensor(pub CollisionObjectHandle);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContactState {
+    Started(Entity),
+    Ongoing(Entity),
+    Stopped(Entity),
+}
+
+impl ContactState {
+    pub fn target(&self) -> Entity {
+        match *self {
+            ContactState::Started(e) => e,
+            ContactState::Ongoing(e) => e,
+            ContactState::Stopped(e) => e,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn started(&self) -> bool {
+        match self {
+            ContactState::Started(_) => true,
+            _ => false,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn stopped(&self) -> bool {
+        match self {
+            ContactState::Stopped(_) => true,
+            _ => false,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn ongoing(&self) -> bool {
+        match self {
+            ContactState::Ongoing(_) => true,
+            _ => false,
+        }
+    }
+}
+
+// In the future we could make this an array so it could
+// be stored inline
+#[derive(Debug, Clone, Component, Default)]
+#[storage(HashMapStorage)]
+pub struct ContactStates(pub Vec<ContactState>);
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ContactStatesData<M>(pub Vec<ContactStateData<M>>);
+
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
+pub enum ContactStateData<M> {
+    Started(M),
+    Ongoing(M),
+    Stopped(M),
+}
+
+impl<M: Debug + Serialize> SaveLoadComponent<M> for ContactStates
+where
+    for<'de> M: Deserialize<'de>,
+{
+    type Data = ContactStatesData<M>;
+    type Error = NoError;
+
+    fn save<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        let mut out = Vec::with_capacity(self.0.len());
+        for col_state in &self.0 {
+            let dat = match col_state {
+                ContactState::Ongoing(e) => ContactStateData::Ongoing(ids(*e).unwrap()),
+                ContactState::Started(e) => ContactStateData::Started(ids(*e).unwrap()),
+                ContactState::Stopped(e) => ContactStateData::Stopped(ids(*e).unwrap()),
+            };
+            out.push(dat);
+        }
+        Ok(ContactStatesData(out))
+    }
+
+    fn load<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>,
+    {
+        let mut out = Vec::with_capacity(data.0.len());
+        for col_state in data.0 {
+            let dat = match col_state {
+                ContactStateData::Ongoing(e) => ContactState::Ongoing(ids(e).unwrap()),
+                ContactStateData::Started(e) => ContactState::Started(ids(e).unwrap()),
+                ContactStateData::Stopped(e) => ContactState::Stopped(ids(e).unwrap()),
+            };
+            out.push(dat);
+        }
+        Ok(ContactStates(out))
+    }
+}

--- a/backends/sky-rts/src/engine/components/mod.rs
+++ b/backends/sky-rts/src/engine/components/mod.rs
@@ -22,11 +22,13 @@ use serde::{Deserialize, Serialize};
 // extend the name a little. Other submods should probably
 // just be named things like `render` rather than
 // `render_component`.
-mod collision;
-mod move_component;
+pub(crate) mod collision;
+pub(crate) mod move_component;
+pub(crate) mod sensor;
 
-pub use self::collision::*;
-pub use self::move_component::*;
+pub use self::{
+    collision::*, move_component::*, sensor::{SensorRadius, SensorType, Sensors},
+};
 
 pub(super) fn register_world_components(world: &mut World) {
     use specs::saveload::U64Marker;
@@ -35,7 +37,6 @@ pub(super) fn register_world_components(world: &mut World) {
     world.register::<Heading>();
     world.register::<Move>();
     world.register::<Movable>();
-    world.register::<Static>();
     world.register::<MovedFlag>();
     world.register::<Hp>();
     world.register::<DealtDamage>();
@@ -45,7 +46,6 @@ pub(super) fn register_world_components(world: &mut World) {
     world.register::<Speed>();
     world.register::<U64Marker>();
     world.register::<FactionId>();
-    world.register::<AttackSensor>();
     world.register::<CollisionHandle>();
     world.register::<UnitTypeTag>();
     world.register::<Attack>();
@@ -53,6 +53,11 @@ pub(super) fn register_world_components(world: &mut World) {
     world.register::<Delete>();
     world.register::<Spawned>();
     world.register::<DataStoreComponent>();
+    world.register::<ContactStates>();
+    world.register::<Owner>();
+    world.register::<SensorType>();
+    world.register::<SensorRadius>();
+    world.register::<Sensors>();
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -167,6 +172,19 @@ impl Shape {
             ..ScaiiShape::default()
         }
     }
+
+    pub fn compute_extended_radius(&self, range: f64) -> f64 {
+        match self {
+            Shape::Triangle { base_len } => {
+                let half_height = base_len / (2.0 as f64).sqrt() / 2.0;
+                half_height + range
+            }
+            Shape::Rect { width, height } => {
+                let half_diagonal = (width * width + height * height).sqrt() / 2.0;
+                half_diagonal + range
+            }
+        }
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Debug, Serialize,
@@ -231,3 +249,32 @@ pub struct Spawned;
 #[derive(Clone, Serialize, Deserialize, Default, Component)]
 #[storage(VecStorage)]
 pub struct DataStoreComponent(pub DataStore);
+
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Component)]
+#[storage(HashMapStorage)]
+pub struct Owner(pub Entity);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnerData<M>(pub M);
+
+impl<M: Debug + Serialize> SaveLoadComponent<M> for Owner
+where
+    for<'de> M: Deserialize<'de>,
+{
+    type Data = OwnerData<M>;
+    type Error = NoError;
+
+    fn save<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        Ok(OwnerData(ids(self.0).unwrap()))
+    }
+
+    fn load<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>,
+    {
+        Ok(Owner(ids(data.0).unwrap()))
+    }
+}

--- a/backends/sky-rts/src/engine/components/move_component.rs
+++ b/backends/sky-rts/src/engine/components/move_component.rs
@@ -17,11 +17,6 @@ pub struct Speed(pub f64);
 #[storage(HashMapStorage)]
 pub struct Movable(pub usize);
 
-// Opposite of movable for entities with a shape that can't be moved
-#[derive(Copy, Clone, Default, Component, PartialEq, Serialize, Deserialize)]
-#[storage(HashMapStorage)]
-pub struct Static(pub usize);
-
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize, Debug)]
 pub enum MoveBehavior {
     Straight,
@@ -30,7 +25,7 @@ pub enum MoveBehavior {
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum MoveTarget {
     Ground(Pos),
-    Unit(Entity),
+    AttackUnit(Entity),
 }
 
 #[derive(Component, Copy, Clone, PartialEq, Debug)]
@@ -41,16 +36,23 @@ pub struct Move {
 }
 
 impl Move {
+    pub fn attack(target: Entity) -> Self {
+        Move {
+            behavior: MoveBehavior::Straight,
+            target: MoveTarget::AttackUnit(target),
+        }
+    }
+
     pub fn is_attacking(&self) -> bool {
         match self.target {
-            MoveTarget::Unit(_) => true,
+            MoveTarget::AttackUnit(_) => true,
             _ => false,
         }
     }
 
     pub fn attack_target(&self) -> Option<Entity> {
         match self.target {
-            MoveTarget::Unit(id) => Some(id),
+            MoveTarget::AttackUnit(id) => Some(id),
             _ => None,
         }
     }
@@ -59,7 +61,7 @@ impl Move {
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub enum MarkedMoveTarget<M> {
     Ground(Pos),
-    Unit(M),
+    AttackUnit(M),
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -83,7 +85,9 @@ where
             behavior: self.behavior,
             target: match self.target {
                 MoveTarget::Ground(pos) => MarkedMoveTarget::Ground(pos),
-                MoveTarget::Unit(entity) => MarkedMoveTarget::Unit(ids(entity).unwrap()),
+                MoveTarget::AttackUnit(entity) => {
+                    MarkedMoveTarget::AttackUnit(ids(entity).unwrap())
+                }
             },
         })
     }
@@ -96,7 +100,7 @@ where
             behavior: data.behavior,
             target: match data.target {
                 MarkedMoveTarget::Ground(pos) => MoveTarget::Ground(pos),
-                MarkedMoveTarget::Unit(mark) => MoveTarget::Unit(ids(mark).unwrap()),
+                MarkedMoveTarget::AttackUnit(mark) => MoveTarget::AttackUnit(ids(mark).unwrap()),
             },
         })
     }

--- a/backends/sky-rts/src/engine/components/sensor.rs
+++ b/backends/sky-rts/src/engine/components/sensor.rs
@@ -1,0 +1,135 @@
+use specs::error::NoError;
+use specs::prelude::*;
+use specs::saveload::SaveLoadComponent;
+use specs::storage::HashMapStorage;
+
+use serde::{Deserialize, Serialize};
+
+use std::{collections::BTreeMap, fmt::Debug};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Component, Serialize,
+         Deserialize)]
+#[storage(HashMapStorage)]
+pub enum SensorType {
+    Attack,
+}
+
+pub fn build_attack_sensor(world: &mut World, owner: Entity, radius: f64) -> Entity {
+    use super::Owner;
+    use specs::saveload::U64Marker;
+    let entity = world
+        .create_entity()
+        .marked::<U64Marker>()
+        .with(SensorType::Attack)
+        .with(Owner(owner))
+        .with(SensorRadius(radius))
+        .build();
+
+    register_sensor_collision(world, entity)
+}
+
+pub fn register_sensor_collision(world: &mut World, sensor: Entity) -> Entity {
+    use super::{FactionId, Owner, Pos};
+    use engine::{
+        components::CollisionHandle,
+        resources::{
+            ColliderData, SkyCollisionWorld, COLLISION_SCALE, SENSOR_BLACKLIST, SENSOR_OFFSET,
+            UNIVERSAL_SENSOR,
+        },
+    };
+    use nalgebra;
+    use nalgebra::{Isometry2, Vector2};
+    use ncollide::{
+        shape::{Ball, ShapeHandle}, world::{CollisionGroups, GeometricQueryType},
+    };
+
+    let sensor_radius = *world.read::<SensorRadius>().get(sensor).unwrap();
+    let c_world = &mut *world.write_resource::<SkyCollisionWorld>();
+
+    let (pos, group_membership) = if let Some(owner) = world.read::<Owner>().get(sensor) {
+        let pos = *world.read::<Pos>().get(owner.0).expect("owner has no pos?");
+        let faction = *world
+            .read::<FactionId>()
+            .get(owner.0)
+            .expect("owner has no faction ID?");
+
+        (pos.0, faction.0 + SENSOR_OFFSET)
+    } else {
+        let pos = *world.read::<Pos>().get(sensor).expect("No owner or pos?");
+        let group = UNIVERSAL_SENSOR;
+
+        (pos.0, group)
+    };
+
+    let mut sensor_group = CollisionGroups::new();
+    sensor_group.set_membership(&[group_membership]);
+    sensor_group.set_blacklist(&SENSOR_BLACKLIST);
+
+    let sensor_shape = Ball::new(sensor_radius.0 / COLLISION_SCALE);
+    let sensor_shape = ShapeHandle::new(sensor_shape);
+
+    let pos = Isometry2::new(
+        Vector2::new(pos.x / COLLISION_SCALE, pos.y / COLLISION_SCALE),
+        nalgebra::zero(),
+    );
+
+    let q_type = GeometricQueryType::Contacts(0.0, 0.0);
+    let collider = c_world.add(
+        pos,
+        sensor_shape,
+        sensor_group,
+        q_type,
+        ColliderData {
+            e: sensor,
+            owner: world.read::<Owner>().get(sensor).map(|v| v.0),
+            sensor: true,
+        },
+    );
+
+    world
+        .write::<CollisionHandle>()
+        .insert(sensor, CollisionHandle(collider));
+
+    sensor
+}
+
+#[derive(Clone, Debug, Copy, Default, PartialEq, PartialOrd, Serialize, Deserialize, Component)]
+#[storage(HashMapStorage)]
+pub struct SensorRadius(pub f64);
+
+#[derive(Clone, Debug, Default, Component)]
+#[storage(HashMapStorage)]
+pub struct Sensors(pub BTreeMap<SensorType, Entity>);
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SensorsData<M>(pub BTreeMap<SensorType, M>);
+
+impl<M: Debug + Serialize> SaveLoadComponent<M> for Sensors
+where
+    for<'de> M: Deserialize<'de>,
+{
+    type Data = SensorsData<M>;
+    type Error = NoError;
+
+    fn save<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
+    where
+        F: FnMut(Entity) -> Option<M>,
+    {
+        let out = self.0.iter().map(|(k, v)| (*k, ids(*v).unwrap())).collect();
+
+        Ok(SensorsData(out))
+    }
+
+    fn load<F>(data: Self::Data, mut ids: F) -> Result<Self, Self::Error>
+    where
+        F: FnMut(M) -> Option<Entity>,
+    {
+        let out = data
+            .0
+            .into_iter()
+            .map(|(k, v)| (k, ids(v).unwrap()))
+            .collect();
+
+        Ok(Sensors(out))
+    }
+}

--- a/backends/sky-rts/src/engine/resources/collision.rs
+++ b/backends/sky-rts/src/engine/resources/collision.rs
@@ -1,11 +1,37 @@
-use nalgebra::{Isometry2, Point2};
-use ncollide::world::CollisionWorld;
+use nalgebra::Isometry2 as I2;
+use nalgebra::Point2 as P2;
+use ncollide::{
+    broad_phase::BroadPhasePairFilter, world::{CollisionObject, CollisionWorld},
+};
 use specs::prelude::*;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
 pub struct ColliderData {
     pub e: Entity,
-    pub detector: bool,
+    pub owner: Option<Entity>,
+    pub sensor: bool,
 }
 
-pub type SkyCollisionWorld = CollisionWorld<Point2<f64>, Isometry2<f64>, ColliderData>;
+pub type SkyCollisionWorld = CollisionWorld<P2<f64>, I2<f64>, ColliderData>;
+
+pub fn new_collision_world() -> SkyCollisionWorld {
+    let mut c_world = SkyCollisionWorld::new(0.02);
+    c_world.register_broad_phase_pair_filter("entity owner filter", SkyBroadPhaseFilter);
+    c_world.update();
+
+    c_world
+}
+
+#[doc(hidden)]
+pub struct SkyBroadPhaseFilter;
+
+impl BroadPhasePairFilter<P2<f64>, I2<f64>, ColliderData> for SkyBroadPhaseFilter {
+    fn is_pair_valid(
+        &self,
+        b1: &CollisionObject<P2<f64>, I2<f64>, ColliderData>,
+        b2: &CollisionObject<P2<f64>, I2<f64>, ColliderData>,
+    ) -> bool {
+        // This seems to not be always working on add?
+        b1.data().owner != Some(b2.data().e) && b2.data().owner != Some(b1.data().e)
+    }
+}

--- a/backends/sky-rts/src/engine/resources/mod.rs
+++ b/backends/sky-rts/src/engine/resources/mod.rs
@@ -1,17 +1,16 @@
 use std::collections::{HashMap, HashSet};
 
 use super::FactionId;
-use engine::components::{AttackSensor, CollisionHandle, Color, DataStoreComponent, Hp, Movable,
-                         Pos, Shape, Speed, Static, UnitTypeTag};
+use engine::components::Color;
 
 use scaii_defs::protos::{Action, State, Viz};
 
 use specs::prelude::*;
-use specs::world::LazyBuilder;
 
 pub mod collision;
+mod unit_type;
 
-pub use self::collision::*;
+pub use self::{collision::*, unit_type::*};
 pub use engine::systems::lua::userdata::DataStore;
 
 // Recommended by ncollide
@@ -20,9 +19,15 @@ pub const COLLISION_MARGIN: f64 = 0.02;
 // we should probably set this as a resource from Lua in the future
 pub const COLLISION_SCALE: f64 = 5.0;
 
-pub const UNIVERSAL_SENSOR: usize = SENSOR_OFFSET+MAX_FACTIONS;
+pub const UNIVERSAL_SENSOR: usize = SENSOR_OFFSET + MAX_FACTIONS;
 pub const SENSOR_OFFSET: usize = MAX_FACTIONS;
-pub const SENSOR_BLACKLIST: [usize; MAX_FACTIONS+1] = [SENSOR_OFFSET, SENSOR_OFFSET+1, SENSOR_OFFSET+2, SENSOR_OFFSET+3, UNIVERSAL_SENSOR];
+pub const SENSOR_BLACKLIST: [usize; MAX_FACTIONS + 1] = [
+    SENSOR_OFFSET,
+    SENSOR_OFFSET + 1,
+    SENSOR_OFFSET + 2,
+    SENSOR_OFFSET + 3,
+    UNIVERSAL_SENSOR,
+];
 
 pub const MAX_FACTIONS: usize = 4;
 
@@ -63,12 +68,14 @@ pub(super) fn register_world_resources(world: &mut World) {
     world.add_resource(UnitTypeMap::default());
     world.add_resource(U64MarkerAllocator::new());
     world.add_resource(ActionInput::default());
-    world.add_resource(SkyCollisionWorld::new(COLLISION_MARGIN));
+    world.add_resource(new_collision_world());
+
     world.add_resource(RtsState(State {
         features: Array3::zeros([STATE_SIZE, STATE_SIZE, 4]).into_raw_vec(),
         feature_array_dims: vec![STATE_SIZE as u32, STATE_SIZE as u32, 4],
         ..Default::default()
     }));
+
     world.add_resource(Reward::default());
     world.add_resource(Skip(false, None));
     world.add_resource(SerializeBytes::default());
@@ -130,233 +137,6 @@ pub struct CumReward(pub HashMap<String, f64>);
 
 #[derive(Eq, PartialEq, Default, Clone, Debug, Hash)]
 pub struct Skip(pub bool, pub Option<String>);
-
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
-pub struct UnitType {
-    pub tag: String,
-    pub max_hp: f64,
-    pub movable: bool,
-    pub shape: Shape,
-    pub kill_reward: f64,
-    pub death_penalty: f64,
-    pub damage_deal_reward: Option<f64>,
-    pub damage_recv_penalty: Option<f64>,
-    pub speed: f64,
-    pub attack_range: f64,
-    pub attack_damage: f64,
-    pub attack_delay: f64,
-
-    pub death_type: String,
-    pub dmg_recv_type: String,
-    pub dmg_deal_type: String,
-    pub kill_type: String,
-}
-
-impl Default for UnitType {
-    fn default() -> Self {
-        UnitType {
-            tag: "".to_string(),
-            max_hp: 100.0,
-            movable: true,
-            shape: Shape::Triangle { base_len: 10.0 },
-            kill_reward: 0.0,
-            death_penalty: 0.0,
-            damage_deal_reward: None,
-            damage_recv_penalty: None,
-            death_type: "death".to_string(),
-            dmg_recv_type: "dmg_recvd".to_string(),
-            dmg_deal_type: "dmg_dealt".to_string(),
-            kill_type: "killed_enemy".to_string(),
-            speed: 20.0,
-            attack_range: 10.0,
-            attack_delay: 1.0,
-            attack_damage: 10.0,
-        }
-    }
-}
-
-impl UnitType {
-    pub fn build_entity(
-        &self,
-        world: &mut World,
-        pos: Pos,
-        curr_hp: Option<f64>,
-        faction: usize,
-    ) -> Entity {
-        let lazy_update = world.read_resource::<LazyUpdate>();
-        let lazy_build = lazy_update.create_entity(&world.entities());
-
-        let players = &**world.read_resource::<Vec<Player>>();
-
-        self.build_entity_lazy(lazy_build, &*lazy_update, pos, curr_hp, faction, players)
-    }
-
-    /// Creates and places the unit in the game world given its initial
-    /// position and faction.
-    ///
-    /// This also initializes anything it needs such as colliders in the collision system.
-    pub fn build_entity_lazy(
-        &self,
-        entity: LazyBuilder,
-        update: &LazyUpdate,
-        pos: Pos,
-        curr_hp: Option<f64>,
-        faction: usize,
-        players: &[Player],
-    ) -> Entity {
-        use specs::saveload::U64Marker;
-
-        let color = players[faction].color;
-
-        // Scoping for borrow shenanigans
-        let entity = {
-            let entity = entity
-                .with(pos)
-                .with(self.shape)
-                .with(color)
-                .with(FactionId(faction))
-                .with(UnitTypeTag(self.tag.clone()))
-                .with(DataStoreComponent::default())
-                .with(Hp {
-                    max_hp: self.max_hp,
-                    curr_hp: curr_hp.unwrap_or(self.max_hp),
-                })
-                .marked::<U64Marker>();
-
-            if self.movable {
-                entity.with(Movable(0)).with(Speed(self.speed))
-            } else {
-                entity.with(Static(0))
-            }
-        }.build();
-
-        let me = self.clone();
-
-        update.execute(move |world| {
-            let mut col_storage = world.write::<CollisionHandle>();
-            let mut atk_storage = world.write::<AttackSensor>();
-
-            let mut c_world = world.write_resource();
-            me.register_collision(
-                entity,
-                pos,
-                faction,
-                &mut col_storage,
-                &mut atk_storage,
-                &mut *c_world,
-            );
-        });
-
-        entity
-    }
-
-    /// Registers a unit with the collision system based on its unit type
-    /// and places the collision system handles into the appropriate components
-    pub fn register_collision(
-        &self,
-        entity: Entity,
-        pos: Pos,
-        faction: usize,
-        col_storage: &mut WriteStorage<CollisionHandle>,
-        atk_storage: &mut WriteStorage<AttackSensor>,
-        c_world: &mut SkyCollisionWorld,
-    ) -> Entity {
-        use nalgebra;
-        use nalgebra::{Isometry2, Vector2};
-        use ncollide::shape::{Ball, Cuboid, Cylinder, ShapeHandle};
-        use ncollide::world::{CollisionGroups, GeometricQueryType};
-
-        let mut collider_group = CollisionGroups::new();
-        collider_group.set_membership(&[faction]);
-
-        let mut sensor_group = CollisionGroups::new();
-        sensor_group.set_membership(&[MAX_FACTIONS + faction]);
-        sensor_group.set_blacklist(&SENSOR_BLACKLIST);
-
-        let atk_radius = self.attack_range / COLLISION_SCALE;
-
-        let (collider, atk_radius) = match self.shape {
-            Shape::Rect { width, height } => {
-                let width = width / COLLISION_SCALE;
-                let height = height / COLLISION_SCALE;
-
-                // ncollide likes half widths and heights, so divide by 2
-                let collider = Cuboid::new(Vector2::new(width / 2.0, height / 2.0));
-                let collider = ShapeHandle::new(collider);
-
-                let half_diagonal = (width*width + height*height).sqrt() / 2.0;
-                let atk_radius = half_diagonal + (self.attack_range / COLLISION_SCALE);
-                let atk_sensor = Ball::new(atk_radius);
-                let atk_sensor = ShapeHandle::new(atk_sensor);
-
-                (collider, atk_sensor)
-            }
-            Shape::Triangle { base_len } => {
-                let base_len = base_len / COLLISION_SCALE;
-
-                // equilateral triangle dimensions
-                let half_height = base_len / (2.0 as f64).sqrt() / 2.0;
-                let radius = base_len / 2.0;
-
-                // A cylinder in 2D is an isoscelese triangle in ncollide
-                let collider = Cylinder::new(half_height, radius);
-                let collider = ShapeHandle::new(collider);
-
-                let atk_radius = half_height + (self.attack_range / COLLISION_SCALE);
-                let atk_sensor = Ball::new(atk_radius);
-                let atk_sensor = ShapeHandle::new(atk_sensor);
-
-                (collider, atk_sensor)
-            }
-        };
-
-        // We need the entity ID for this, so do it after building the entity and then add the component.
-        let (collider, atk_radius) = {
-            let pos = Isometry2::new(
-                Vector2::new(pos.x / COLLISION_SCALE, pos.y / COLLISION_SCALE),
-                nalgebra::zero(),
-            );
-
-            let q_type = GeometricQueryType::Contacts(0.0, 0.0);
-            let collider = c_world.add(
-                pos,
-                collider,
-                collider_group,
-                q_type,
-                ColliderData {
-                    e: entity,
-                    detector: false,
-                },
-            );
-
-            let atk_radius = c_world.add(
-                pos,
-                atk_radius,
-                sensor_group,
-                q_type,
-                ColliderData {
-                    e: entity,
-                    detector: true,
-                },
-            );
-
-            (collider, atk_radius)
-        };
-
-        col_storage.insert(entity, CollisionHandle(collider));
-        atk_storage.insert(entity, AttackSensor(atk_radius));
-
-        c_world.update();
-
-        entity
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct UnitTypeMap {
-    pub typ_ids: HashMap<String, usize>,
-    pub tag_map: HashMap<String, UnitType>,
-}
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct SerializeBytes(pub Vec<u8>);

--- a/backends/sky-rts/src/engine/resources/unit_type.rs
+++ b/backends/sky-rts/src/engine/resources/unit_type.rs
@@ -1,0 +1,188 @@
+use engine::{
+    components::{CollisionHandle, DataStoreComponent, Pos, Shape}, resources::SkyCollisionWorld,
+};
+use specs::prelude::*;
+
+use std::collections::HashMap;
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct UnitType {
+    pub tag: String,
+    pub max_hp: f64,
+    pub movable: bool,
+    pub shape: Shape,
+    pub kill_reward: f64,
+    pub death_penalty: f64,
+    pub damage_deal_reward: Option<f64>,
+    pub damage_recv_penalty: Option<f64>,
+    pub speed: f64,
+    pub attack_range: f64,
+    pub attack_damage: f64,
+    pub attack_delay: f64,
+
+    pub death_type: String,
+    pub dmg_recv_type: String,
+    pub dmg_deal_type: String,
+    pub kill_type: String,
+}
+
+impl Default for UnitType {
+    fn default() -> Self {
+        UnitType {
+            tag: "".to_string(),
+            max_hp: 100.0,
+            movable: true,
+            shape: Shape::Triangle { base_len: 10.0 },
+            kill_reward: 0.0,
+            death_penalty: 0.0,
+            damage_deal_reward: None,
+            damage_recv_penalty: None,
+            death_type: "death".to_string(),
+            dmg_recv_type: "dmg_recvd".to_string(),
+            dmg_deal_type: "dmg_dealt".to_string(),
+            kill_type: "killed_enemy".to_string(),
+            speed: 20.0,
+            attack_range: 10.0,
+            attack_delay: 1.0,
+            attack_damage: 10.0,
+        }
+    }
+}
+
+impl UnitType {
+    pub fn build_entity(
+        &self,
+        world: &mut World,
+        pos: Pos,
+        curr_hp: Option<f64>,
+        faction: usize,
+    ) -> Entity {
+        use engine::{
+            components::{sensor, FactionId, Hp, Movable, SensorType, Sensors, Speed, UnitTypeTag},
+            resources::PLAYER_COLORS,
+        };
+        use specs::saveload::U64Marker;
+
+        let color = PLAYER_COLORS[faction];
+
+        // Scoping for borrow shenanigans
+        let entity = {
+            let entity = world
+                .create_entity()
+                .with(pos)
+                .with(self.shape)
+                .with(color)
+                .with(FactionId(faction))
+                .with(UnitTypeTag(self.tag.clone()))
+                .with(DataStoreComponent::default())
+                .with(Hp {
+                    max_hp: self.max_hp,
+                    curr_hp: curr_hp.unwrap_or(self.max_hp),
+                })
+                .marked::<U64Marker>();
+
+            if self.movable {
+                entity.with(Movable(0)).with(Speed(self.speed))
+            } else {
+                entity
+            }
+        }.build();
+
+        let me = {
+            let mut col_storage = world.write::<CollisionHandle>();
+            let mut c_world = world.write_resource();
+
+            self.register_collision(entity, pos, faction, &mut col_storage, &mut *c_world)
+        };
+
+        let atk_radius = self.shape.compute_extended_radius(self.attack_range);
+        let atk_sensor = sensor::build_attack_sensor(world, me, atk_radius);
+        world
+            .write::<Sensors>()
+            .entry(me)
+            .unwrap()
+            .or_insert(Default::default())
+            .0
+            .insert(SensorType::Attack, atk_sensor);
+
+        me
+    }
+
+    /// Registers a unit with the collision system based on its unit type
+    /// and places the collision system handles into the appropriate components
+    pub fn register_collision(
+        &self,
+        entity: Entity,
+        pos: Pos,
+        faction: usize,
+        col_storage: &mut WriteStorage<CollisionHandle>,
+        c_world: &mut SkyCollisionWorld,
+    ) -> Entity {
+        use engine::{
+            components::Shape, resources::{ColliderData, COLLISION_SCALE},
+        };
+        use nalgebra;
+        use nalgebra::{Isometry2, Vector2};
+        use ncollide::{
+            shape::{Cuboid, Cylinder, ShapeHandle}, world::{CollisionGroups, GeometricQueryType},
+        };
+
+        let mut collider_group = CollisionGroups::new();
+        collider_group.set_membership(&[faction]);
+
+        let collider = match self.shape {
+            Shape::Rect { width, height } => {
+                let width = width / COLLISION_SCALE;
+                let height = height / COLLISION_SCALE;
+
+                // ncollide likes half widths and heights, so divide by 2
+                let collider = Cuboid::new(Vector2::new(width / 2.0, height / 2.0));
+                let collider = ShapeHandle::new(collider);
+
+                collider
+            }
+            Shape::Triangle { base_len } => {
+                let base_len = base_len / COLLISION_SCALE;
+
+                // equilateral triangle dimensions
+                let half_height = base_len / (2.0 as f64).sqrt() / 2.0;
+                let radius = base_len / 2.0;
+
+                // A cylinder in 2D is an isoscelese triangle in ncollide
+                let collider = Cylinder::new(half_height, radius);
+                let collider = ShapeHandle::new(collider);
+
+                collider
+            }
+        };
+
+        // We need the entity ID for this, so do it after building the entity and then add the component.
+        let pos = Isometry2::new(
+            Vector2::new(pos.x / COLLISION_SCALE, pos.y / COLLISION_SCALE),
+            nalgebra::zero(),
+        );
+
+        let q_type = GeometricQueryType::Contacts(0.0, 0.0);
+        let collider = c_world.add(
+            pos,
+            collider,
+            collider_group,
+            q_type,
+            ColliderData {
+                e: entity,
+                owner: None,
+                sensor: false,
+            },
+        );
+
+        col_storage.insert(entity, CollisionHandle(collider));
+
+        entity
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct UnitTypeMap {
+    pub typ_ids: HashMap<String, usize>,
+    pub tag_map: HashMap<String, UnitType>,
+}

--- a/backends/sky-rts/src/engine/systems/cleanup.rs
+++ b/backends/sky-rts/src/engine/systems/cleanup.rs
@@ -1,5 +1,6 @@
 use engine::components::{
-    AttackSensor, CollisionHandle, DealtDamage, Death, Delete, HpChange, MovedFlag, Spawned,
+    CollisionHandle, ContactState, ContactStates, DealtDamage, Death, Delete, HpChange, MovedFlag,
+    Sensors, Spawned,
 };
 use engine::resources::SkyCollisionWorld;
 use specs::prelude::*;
@@ -12,11 +13,12 @@ pub struct CleanupSystemData<'a> {
     moved: WriteStorage<'a, MovedFlag>,
     dealt_dmg: WriteStorage<'a, DealtDamage>,
     hp_change: WriteStorage<'a, HpChange>,
+    contact_states: WriteStorage<'a, ContactStates>,
     entities: Entities<'a>,
-    collision_sys: FetchMut<'a, SkyCollisionWorld>,
+    c_world: FetchMut<'a, SkyCollisionWorld>,
 
-    col_handle: ReadStorage<'a, CollisionHandle>,
-    atk_radius: ReadStorage<'a, AttackSensor>,
+    c_handles: ReadStorage<'a, CollisionHandle>,
+    sensors: ReadStorage<'a, Sensors>,
 }
 
 #[derive(Default)]
@@ -31,28 +33,70 @@ impl<'a> System<'a> for CleanupSystem {
         sys_data.hp_change.clear();
         sys_data.spawned.clear();
 
-        for (id, col_handle, atk_radius, _) in (
-            &*sys_data.entities,
-            &sys_data.col_handle,
-            &sys_data.atk_radius,
-            sys_data.death.drain(),
-        ).join()
-        {
-            sys_data.entities.delete(id).unwrap();
-
-            sys_data.collision_sys.remove(&[col_handle.0, atk_radius.0]);
+        for (id, _) in (&*sys_data.entities, sys_data.death.drain()).join() {
+            finalize_entity(
+                id,
+                &sys_data.entities,
+                &sys_data.sensors,
+                &sys_data.c_handles,
+                &mut sys_data.c_world,
+            );
         }
 
-        for (id, col_handle, atk_radius, _) in (
-            &*sys_data.entities,
-            &sys_data.col_handle,
-            &sys_data.atk_radius,
-            sys_data.delete.drain(),
-        ).join()
-        {
-            sys_data.entities.delete(id).unwrap();
+        for (id, _) in (&*sys_data.entities, sys_data.delete.drain()).join() {
+            finalize_entity(
+                id,
+                &sys_data.entities,
+                &sys_data.sensors,
+                &sys_data.c_handles,
+                &mut sys_data.c_world,
+            );
+        }
 
-            sys_data.collision_sys.remove(&[col_handle.0, atk_radius.0]);
+        for states in (&mut sys_data.contact_states).join() {
+            collision_advancements(&mut states.0, &sys_data.entities);
+        }
+    }
+}
+
+/// Removes any Entity and its related children (such as sensors).
+fn finalize_entity(
+    id: Entity,
+    entities: &Entities,
+    sensors: &ReadStorage<Sensors>,
+    c_handles: &ReadStorage<CollisionHandle>,
+    c_world: &mut SkyCollisionWorld,
+) {
+    // Due to the interaction of sensors/child objects in general
+    // and delete_all we need to verify the collision object is actually
+    // being deleted
+    if let Some(sensors) = sensors.get(id) {
+        for &sensor in sensors.0.values() {
+            let handle = c_handles.get(sensor).expect("Sensor has no collision?");
+
+            if c_world.collision_object(handle.0).is_some() {
+                c_world.remove(&[handle.0]);
+            }
+
+            entities.delete(sensor).unwrap();
+        }
+    }
+    entities.delete(id).unwrap();
+
+    if let Some(handle) = c_handles.get(id) {
+        if c_world.collision_object(handle.0).is_some() {
+            c_world.remove(&[handle.0]);
+        }
+    }
+}
+
+/// Filters expired collisions, collisions with dead entities, and then
+/// switches new collisions to ongoing ones
+fn collision_advancements(states: &mut Vec<ContactState>, entities: &Entities) {
+    states.retain(|v| !v.stopped() && entities.is_alive(v.target()));
+    for state in states.iter_mut() {
+        if state.started() {
+            *state = ContactState::Ongoing(state.target());
         }
     }
 }

--- a/backends/sky-rts/src/engine/systems/collision.rs
+++ b/backends/sky-rts/src/engine/systems/collision.rs
@@ -1,5 +1,6 @@
-use engine::components::{Attack, AttackSensor, CollisionHandle, FactionId, Move, MovedFlag, Pos};
+use engine::components::{CollisionHandle, ContactState, ContactStates, MovedFlag, Pos, Sensors};
 use engine::resources::SkyCollisionWorld;
+use ncollide::world::CollisionObjectHandle;
 use specs::prelude::*;
 
 #[derive(SystemData)]
@@ -7,14 +8,23 @@ pub struct CollisionSystemData<'a> {
     moved: ReadStorage<'a, MovedFlag>,
     pos: ReadStorage<'a, Pos>,
     c_handle: ReadStorage<'a, CollisionHandle>,
-    atk_radius: ReadStorage<'a, AttackSensor>,
-    faction: ReadStorage<'a, FactionId>,
+    sensors: ReadStorage<'a, Sensors>,
+    ids: Entities<'a>,
 
-    moving: WriteStorage<'a, Move>,
-    attack: WriteStorage<'a, Attack>,
+    contact_states: WriteStorage<'a, ContactStates>,
+
     col_world: FetchMut<'a, SkyCollisionWorld>,
 }
 
+/// The `CollisionSystem` updates a moved entity's collisiion-related
+/// marker positions (e.g. attack whiskers, rigid body, etc)
+/// and registers the corresponding contact event components when collisions occur.
+///
+/// This is not responsible for removing no-longer happening collisions. That is the job
+/// of the `CleanupSystem` which will remove `Stopped` collisions every update cycle.
+///
+/// In addition, other systems should verify their target has not disappeared, especially if relying on
+/// `Ongoing` collision tags.
 pub struct CollisionSystem;
 
 impl<'a> System<'a> for CollisionSystem {
@@ -24,12 +34,13 @@ impl<'a> System<'a> for CollisionSystem {
         use engine::resources::COLLISION_SCALE;
         use nalgebra;
         use nalgebra::{Isometry2, Vector2};
+        use ncollide::events::ContactEvent;
 
-        for (_, pos, c_handle, atk_handle) in (
+        for (_, pos, c_handle, id) in (
             &sys_data.moved,
             &sys_data.pos,
             &sys_data.c_handle,
-            &sys_data.atk_radius,
+            &*sys_data.ids,
         ).join()
         {
             let pos = Isometry2::new(
@@ -38,93 +49,170 @@ impl<'a> System<'a> for CollisionSystem {
             );
 
             sys_data.col_world.set_position(c_handle.0, pos);
-            sys_data.col_world.set_position(atk_handle.0, pos);
+
+            if let Some(sensors) = sys_data.sensors.get(id) {
+                for &sensor in sensors.0.values() {
+                    let sensor_ch = sys_data
+                        .c_handle
+                        .get(sensor)
+                        .expect("Sensor has no collision?");
+                    sys_data.col_world.set_position(sensor_ch.0, pos);
+                }
+            }
         }
 
         sys_data.col_world.update();
 
-        for (obj1, obj2, _) in sys_data.col_world.contacts() {
-            let eid1 = obj1.data().e;
-            let eid2 = obj2.data().e;
-
-            if eid1 == eid2 {
-                continue;
-            }
-
-            let atk_radius1 = sys_data.atk_radius.get(eid1).unwrap();
-            let atk_radius2 = sys_data.atk_radius.get(eid2).unwrap();
-
-            let faction1 = sys_data.faction.get(eid1).unwrap().0;
-            let faction2 = sys_data.faction.get(eid2).unwrap().0;
-
-            match (
-                obj1.handle() == atk_radius1.0,
-                obj2.handle() == atk_radius2.0,
-            ) {
-                (true, false) => acquire_target(
-                    eid1,
-                    eid2,
-                    &mut sys_data.moving,
-                    &mut sys_data.attack,
-                    faction1,
-                    faction2,
-                ),
-                (false, true) => acquire_target(
-                    eid2,
-                    eid1,
-                    &mut sys_data.moving,
-                    &mut sys_data.attack,
-                    faction2,
-                    faction1,
-                ),
-                (true, true) => {} // technically unreachable with our blacklist
-                (false, false) => {
-                    continue; //unimplemented, actual bodies are colliding
+        for event in sys_data.col_world.contact_events() {
+            print!("Collision event: {:?} :::  ", event);
+            match event {
+                ContactEvent::Started(h1, h2) => {
+                    handle_started(&sys_data.col_world, &mut sys_data.contact_states, *h1, *h2);
+                }
+                ContactEvent::Stopped(h1, h2) => {
+                    handle_stopped(&sys_data.col_world, &mut sys_data.contact_states, *h1, *h2);
                 }
             }
         }
     }
 }
 
-fn acquire_target<'a>(
-    me: Entity,
-    other_id: Entity,
-    moving: &mut WriteStorage<'a, Move>,
-    attack: &mut WriteStorage<'a, Attack>,
-    faction1: usize,
-    faction2: usize,
+/// Inserts contact events into storages as they happen.
+///
+/// If one of the handles is a sensor, this will only flag the sensor's contact events.
+///
+/// If neither is a sensor, both will be flagged with a `Started` pointing
+/// to the opposite entity's `Entity` handle.
+///
+/// During debug builds, this will verify that entities do not double-appear in
+/// an entity's collision list, as well as verifying that sensors do not detect
+/// each other.
+fn handle_started(
+    col_world: &SkyCollisionWorld,
+    contact_states: &mut WriteStorage<ContactStates>,
+    h1: CollisionObjectHandle,
+    h2: CollisionObjectHandle,
 ) {
-    use std::f64;
-    let explicit_atk = {
-        let move_order = moving.get_mut(me);
-        if move_order.is_some() {
-            let move_order = move_order.unwrap();
+    let h1 = col_world.collision_object(h1).unwrap();
+    let h2 = col_world.collision_object(h2).unwrap();
 
-            if (move_order.is_attacking() && move_order.attack_target().unwrap() != other_id)
-                || !move_order.is_attacking()
-            {
-                return;
-            }
+    let e1 = h1.data().e;
+    let e2 = h2.data().e;
 
-            true
-        } else {
-            false
+    println!("Data1: {:?} Data2: {:?} ", h1.data(), h2.data());
+
+    debug_assert!(!(h1.data().sensor && h2.data().sensor));
+
+    if h1.data().sensor {
+        let states = &mut contact_states
+            .entry(e1)
+            .unwrap()
+            .or_insert(Default::default())
+            .0;
+        debug_assert!(states.iter().filter(|v| v.target() == e2).count() == 0);
+        states.push(ContactState::Started(e2));
+    } else if h2.data().sensor {
+        let states = &mut contact_states
+            .entry(e2)
+            .unwrap()
+            .or_insert(Default::default())
+            .0;
+        debug_assert!(states.iter().filter(|v| v.target() == e1).count() == 0);
+        states.push(ContactState::Started(e1));
+    } else {
+        {
+            let states = &mut contact_states
+                .entry(e1)
+                .unwrap()
+                .or_insert(Default::default())
+                .0;
+            debug_assert!(states.iter().filter(|v| v.target() == e2).count() == 0);
+            states.push(ContactState::Started(e2));
         }
-    };
-    moving.remove(me);
 
-    if attack.get(me).is_some() {
+        let states = &mut contact_states
+            .entry(e2)
+            .unwrap()
+            .or_insert(Default::default())
+            .0;
+        debug_assert!(states.iter().filter(|v| v.target() == e1).count() == 0);
+        states.push(ContactState::Started(e1));
+    }
+}
+
+/// Changes contact events into `Stopped` versions as they happen.
+///
+/// If one of the handles is a sensor, this will find the sensor's existing `Start`
+/// or `Ongoing` corresponding to the detected entity and change it to `Stopped`
+///
+/// If neither is a sensor, this will symmetrically flag both with a `Stopped`
+/// in the same manner.
+///
+/// During debug builds, this will verify that the target entity appears exactly
+/// once in a list, as well as verifying that sensors do not detect
+/// each other.
+fn handle_stopped(
+    col_world: &SkyCollisionWorld,
+    contact_states: &mut WriteStorage<ContactStates>,
+    h1: CollisionObjectHandle,
+    h2: CollisionObjectHandle,
+) {
+    let h1 = col_world.collision_object(h1).unwrap();
+    let h2 = col_world.collision_object(h2).unwrap();
+
+    let e1 = h1.data().e;
+    let e2 = h1.data().e;
+
+    println!("Data1: {:?} Data2: {:?} ", h1.data(), h2.data());
+
+    if e1 == e2 {
         return;
     }
 
-    // Allows people to attack their own units, but only with an explicit order
-    if explicit_atk || faction1 != faction2 {
-        attack.insert(
-            me,
-            Attack {
-                target: other_id,
-                time_since_last: f64::INFINITY,
-            },
-        );
+    debug_assert!(!(h1.data().sensor && h2.data().sensor));
+
+    if h1.data().sensor {
+        let states = &mut contact_states
+            .entry(e1)
+            .unwrap()
+            .or_insert(Default::default())
+            .0;
+        debug_assert!(states.iter().filter(|v| v.target() == e2).count() == 1);
+
+        for v in states.iter_mut().filter(|v| v.target() == e2) {
+            *v = ContactState::Stopped(v.target());
+        }
+    } else if h2.data().sensor {
+        let states = &mut contact_states
+            .entry(e2)
+            .unwrap()
+            .or_insert(Default::default())
+            .0;
+        debug_assert!(states.iter().filter(|v| v.target() == e1).count() == 1);
+        for v in states.iter_mut().filter(|v| v.target() == e2) {
+            *v = ContactState::Stopped(v.target());
+        }
+    } else {
+        {
+            let states = &mut contact_states
+                .entry(e1)
+                .unwrap()
+                .or_insert(Default::default())
+                .0;
+            debug_assert!(states.iter().filter(|v| v.target() == e2).count() == 1);
+            for v in states.iter_mut().filter(|v| v.target() == e2) {
+                *v = ContactState::Stopped(v.target());
+            }
+        }
+
+        let states = &mut contact_states
+            .entry(e2)
+            .unwrap()
+            .or_insert(Default::default())
+            .0;
+        debug_assert!(states.iter().filter(|v| v.target() == e1).count() == 1);
+        for v in states.iter_mut().filter(|v| v.target() == e2) {
+            *v = ContactState::Stopped(v.target());
+        }
     }
 }

--- a/backends/sky-rts/src/engine/systems/input.rs
+++ b/backends/sky-rts/src/engine/systems/input.rs
@@ -66,7 +66,7 @@ impl<'a> System<'a> for InputSystem {
 
                     Move {
                         behavior: MoveBehavior::Straight,
-                        target: MoveTarget::Unit(target),
+                        target: MoveTarget::AttackUnit(target),
                     }
                 }
             };
@@ -170,7 +170,7 @@ mod tests {
 
         sys.dispatch(&mut world.res);
         let moves = world.read::<Move>();
-        assert!(moves.get(test_player).unwrap().target == MoveTarget::Unit(test_target)); // Verifies that test_player's target is test target
+        assert!(moves.get(test_player).unwrap().target == MoveTarget::AttackUnit(test_target)); // Verifies that test_player's target is test target
         assert!(moves.get(test_player).unwrap().behavior == MoveBehavior::Straight); // Verifies that test_player's move behavior is straight
     }
 

--- a/backends/sky-rts/src/engine/systems/lua/userdata.rs
+++ b/backends/sky-rts/src/engine/systems/lua/userdata.rs
@@ -1,6 +1,6 @@
-use rlua::{Lua, UserData, UserDataMethods, Value};
-use rlua::String as LuaString;
 use rlua::Error as LuaError;
+use rlua::String as LuaString;
+use rlua::{Lua, UserData, UserDataMethods, Value};
 
 use engine::components::{FactionId, Hp, Pos};
 use engine::resources::Spawn;
@@ -37,6 +37,7 @@ impl DataStore {
     }
 
     /// Returns the overall size of the underlying storage
+    #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.int_data.len() + self.float_data.len() + self.string_data.len() + self.bool_data.len()
     }
@@ -44,21 +45,25 @@ impl DataStore {
     /// A "display" workaround for the fact that we can't do protobuf maps with Javascript right now
     ///
     /// This is just for setting fields in the Viz packet
+    #[allow(dead_code)]
     pub fn display_all(&self, out: Option<HashMap<String, String>>) -> HashMap<String, String> {
         let mut out = out.unwrap_or_else(|| HashMap::with_capacity(self.len()));
         out.clear();
 
-        let iter = self.int_data
+        let iter = self
+            .int_data
             .iter()
             .map(|(k, v)| (k.clone(), format!("{}", v)));
         out.extend(iter);
 
-        let iter = self.float_data
+        let iter = self
+            .float_data
             .iter()
             .map(|(k, v)| (k.clone(), format!("{}", v)));
         out.extend(iter);
 
-        let iter = self.bool_data
+        let iter = self
+            .bool_data
             .iter()
             .map(|(k, v)| (k.clone(), format!("{}", v)));
         out.extend(iter);
@@ -130,8 +135,8 @@ impl DataStore {
 
 impl UserData for DataStore {
     fn add_methods(methods: &mut UserDataMethods<Self>) {
-        use rlua::{MetaMethod, Value};
         use rlua::String as LuaString;
+        use rlua::{MetaMethod, Value};
 
         methods.add_meta_method(MetaMethod::Index, |lua, this, idx: LuaString| {
             this.handle_index(lua, idx)
@@ -372,8 +377,8 @@ store.pi = 3.14"#;
 
     #[test]
     fn lua_data_store_member() {
-        use rlua::{Lua, Number};
         use super::{DataStore, UserDataUnit};
+        use rlua::{Lua, Number};
         let mut lua = Lua::new();
 
         let mut store = DataStore::default();
@@ -386,7 +391,8 @@ store.pi = 3.14"#;
 
         assert_eq!(store.int_data.get("x"), Some(&5));
 
-        let pi = lua.exec::<Number>("return store.pi", Some("member read"))
+        let pi = lua
+            .exec::<Number>("return store.pi", Some("member read"))
             .unwrap();
         assert_eq!(pi, 3.14);
     }

--- a/backends/sky-rts/src/engine/systems/movement.rs
+++ b/backends/sky-rts/src/engine/systems/movement.rs
@@ -46,7 +46,7 @@ impl<'a> System<'a> for MoveSystem {
                 // For borrow reasons, we need to defer targeted moves until later
                 // (we can't get a position while iterating over positions!)
                 Move {
-                    target: MoveTarget::Unit(target),
+                    target: MoveTarget::AttackUnit(target),
                     ..
                 } => {
                     targets.push((id, target));

--- a/backends/sky-rts/src/engine/systems/serde/mod.rs
+++ b/backends/sky-rts/src/engine/systems/serde/mod.rs
@@ -6,8 +6,10 @@ pub use self::de::DeserializeSystem;
 pub use self::de_collision::RedoCollisionSys;
 pub use self::ser::SerializeSystem;
 
-use engine::components::{Attack, Color, DataStoreComponent, FactionId, Hp, Movable, Move, Pos,
-                         Shape, Speed, Static, UnitTypeTag};
+use engine::components::{
+    Attack, Color, ContactStates, DataStoreComponent, FactionId, Hp, Movable, Move, Owner, Pos,
+    SensorRadius, SensorType, Sensors, Shape, Speed, UnitTypeTag,
+};
 use engine::resources::{CumReward, DataStore, LuaPath, SpawnBuffer, Terminal};
 use rand::Isaac64Rng;
 
@@ -28,7 +30,6 @@ struct SerTarget {
 type SerComponents = (
     Speed,
     Movable,
-    Static,
     Move,
     Pos,
     Hp,
@@ -38,4 +39,9 @@ type SerComponents = (
     Attack,
     UnitTypeTag,
     DataStoreComponent,
+    ContactStates,
+    Sensors,
+    SensorType,
+    SensorRadius,
+    Owner,
 );

--- a/backends/sky-rts/src/engine/systems/spawn.rs
+++ b/backends/sky-rts/src/engine/systems/spawn.rs
@@ -1,46 +1,25 @@
 use engine::components::Spawned;
-use engine::resources::{Deserializing, Player, SkyCollisionWorld, SpawnBuffer, UnitTypeMap};
+use engine::resources::{SpawnBuffer, UnitTypeMap};
 use specs::prelude::*;
-
-#[derive(SystemData)]
-pub struct SpawnSystemData<'a> {
-    deserializing: Fetch<'a, Deserializing>,
-    lazy_update: Fetch<'a, LazyUpdate>,
-    spawn_buf: FetchMut<'a, SpawnBuffer>,
-    type_map: Fetch<'a, UnitTypeMap>,
-    players: Fetch<'a, Vec<Player>>,
-    entities: Entities<'a>,
-}
 
 #[derive(Default)]
 pub struct SpawnSystem {
     spawn_buf_bak: SpawnBuffer,
+    spawn_buf_tmp: SpawnBuffer,
 }
 
-impl<'a> System<'a> for SpawnSystem {
-    type SystemData = SpawnSystemData<'a>;
-
-    fn run(&mut self, mut sys_data: Self::SystemData) {
+impl SpawnSystem {
+    pub fn update(&mut self, world: &mut World) {
         use std::mem;
 
-        // Skip this if we're deserializing because
-        // we need to run the output systems at the end
-        // but don't want to accidentally get spawn counters
-        // out of sync
-        if sys_data.deserializing.0 {
-            return;
-        }
+        self.spawn_buf_tmp.0.clear();
 
-        // borrow checker workaround
-        let (lazy_update, entities, type_map, players, spawn_buf) = (
-            &*sys_data.lazy_update,
-            &*sys_data.entities,
-            &*sys_data.type_map,
-            &*sys_data.players,
-            &mut *sys_data.spawn_buf,
+        // Need this for borrow checking or we're just borrowing world while we try to pass it
+        // mutably
+        mem::swap(
+            &mut self.spawn_buf_tmp,
+            &mut *world.write_resource::<SpawnBuffer>(),
         );
-
-        let buf_len = spawn_buf.0.len();
 
         // We're basically just "pouring" one bucket into another through a mesh
         //
@@ -49,24 +28,23 @@ impl<'a> System<'a> for SpawnSystem {
         // and let it naturally filter into the backup buffer
         self.spawn_buf_bak
             .0
-            .extend(spawn_buf.0.drain(..).filter_map(|mut spawn| {
+            .extend(self.spawn_buf_tmp.0.drain(..).filter_map(|mut spawn| {
                 if spawn.delay <= 1 {
-                    let u_type = type_map.tag_map.get(&spawn.u_type).expect(&format!(
-                        "Unknown unit type {} at spawn of {:?}",
-                        spawn.u_type, spawn,
-                    ));
+                    // really unfortunate but we need to clone for borrow checker
+                    let u_type = world
+                        .read_resource::<UnitTypeMap>()
+                        .tag_map
+                        .get(&spawn.u_type)
+                        .expect(&format!(
+                            "Unknown unit type {} at spawn of {:?}",
+                            spawn.u_type, spawn,
+                        ))
+                        .clone();
 
-                    let build = lazy_update.create_entity(entities);
+                    let entity =
+                        u_type.build_entity(world, spawn.pos, spawn.curr_hp, spawn.faction);
 
-                    let entity = u_type.build_entity_lazy(
-                        build,
-                        &*lazy_update,
-                        spawn.pos,
-                        spawn.curr_hp,
-                        spawn.faction,
-                        &*players,
-                    );
-                    lazy_update.insert(entity, Spawned);
+                    world.write::<Spawned>().insert(entity, Spawned);
 
                     None
                 } else {
@@ -75,16 +53,9 @@ impl<'a> System<'a> for SpawnSystem {
                 }
             }));
 
-        let new_len = self.spawn_buf_bak.0.len();
-
-        // If we have fewer elements, we did some spawns and also have to cue up a world update for collision
-        // purposes
-        if new_len < buf_len {
-            lazy_update.execute(|world| {
-                world.write_resource::<SkyCollisionWorld>().update();
-            });
-        }
-
-        mem::swap(spawn_buf, &mut self.spawn_buf_bak);
+        mem::swap(
+            &mut *world.write_resource::<SpawnBuffer>(),
+            &mut self.spawn_buf_bak,
+        );
     }
 }

--- a/backends/sky-rts/src/engine/systems/state.rs
+++ b/backends/sky-rts/src/engine/systems/state.rs
@@ -37,7 +37,7 @@ impl<'a> System<'a> for StateBuildSystem {
     type SystemData = StateBuildSystemData<'a>;
 
     fn run(&mut self, mut sys_data: Self::SystemData) {
-        use engine::resources::{UNIVERSAL_SENSOR, COLLISION_SCALE};
+        use engine::resources::{COLLISION_SCALE, UNIVERSAL_SENSOR};
         use nalgebra::Point2;
         use ncollide::world::CollisionGroups;
         use std::mem;
@@ -64,7 +64,7 @@ impl<'a> System<'a> for StateBuildSystem {
                 );
                 let intersection = c_world.interferences_with_point(&pt, &c_group);
 
-                if let Some(collider) = intersection.filter(|v| !v.data().detector).next() {
+                if let Some(collider) = intersection.filter(|v| !v.data().sensor).next() {
                     let entity = collider.data().e;
                     // Need to offset by 1 because the default is 0
                     self.state_cache[(i, j, 0)] = (entity.id() + 1) as f64;

--- a/viz/js/session.js
+++ b/viz/js/session.js
@@ -157,7 +157,9 @@ function handleVizInit(vizInit) {
 		if (vizInit.getTestMode()) {
 			testingMode = true;
 		}
-	}
+    }
+    // start fresh with entities
+    masterEntities = {};
 	// ignoring gameboard width and height, assume 40 x 40
 }
 function handleViz(vizData) {


### PR DESCRIPTION
Rework collision in preparation for Trigger Volumes (#103). 

Adds a collision system which generates collision events that then
propagate forward each frame, rather than handling everything in
the collision system itself.

This also splits sensors into their own entities that know their parent
(just as units know their sensor children). Sensors are just renderless
entities with a `TriggerType` and some collision, and extra things
for each SensorType. For instance, `AttackSensors` have an owner but
a trigger may have a position and a trigger.